### PR TITLE
Make the generated docker-compose.yml extendable

### DIFF
--- a/src/Console/Commands/DockerBuild.php
+++ b/src/Console/Commands/DockerBuild.php
@@ -12,7 +12,11 @@ class DockerBuild extends Command
      *
      * @var string
      */
-    protected $signature = 'docker:build {--p|print : Only print the Dockerfile} {--s|save : Only save the Dockerfile} {--P|push : Push the image}';
+    protected $signature = 'docker:build'
+        . ' {--p|print : Only print the Dockerfile}'
+        . ' {--s|save : Only save the Dockerfile} '
+        . ' {--P|push : Push the image}'
+        . ' {--I|print-image-tag : Only print the image tag}';
 
     /**
      * The console command description.
@@ -93,6 +97,14 @@ class DockerBuild extends Command
 
         //
         $imageInfo = static::getImageInfo();
+
+        //
+        if ($this->option("print-image-tag"))
+        {
+            $this->info($imageInfo["image"]);
+
+            return 0;
+        }
 
         $dockerfile = str_replace('${DOCKERIZE_VERSION}', $imageInfo["version"], $dockerfile);
         $dockerfile = str_replace('${DOCKERIZE_BRANCH}', $imageInfo["branch"], $dockerfile);

--- a/src/Console/Commands/DockerBuild.php
+++ b/src/Console/Commands/DockerBuild.php
@@ -153,7 +153,13 @@ class DockerBuild extends Command
             $this->line("* " . trim($line));
         }
 
-        pclose($fd);
+        $exitCode = pclose($fd);
+
+        if ($exitCode !== 0)
+        {
+            // explicitly call exit() so that we can use the exit code in a shell!
+            exit($exitCode);
+        }
 
         return 0;
     }


### PR DESCRIPTION
# Proof-of-Concept / Suggestion

## What?

Extend the docker-compose.yml by calling a PHP config file which returns a special **transformer function**.

# Example

In any of the environment files (`.env`, `.dockerize.env`, `$APP_ENV/dockerize.env`, ...), add the following line:

```ini
DOCKERIZE_COMPOSE_TRANSFORMER=".local/services.php"
```

The PHP config file should return a `function($yaml): array` like so:

```php
<?php

/**
 * Extend the YAML to add a scheduler and queue
 * 
 * This is very helpful for the Apache based rootless base image
 */
return function($yaml)
{
    // Add a scheduler services (clone the app service, remove ports!)	
    $yaml["services"]["sched"] = $yaml["services"]["app"];
    unset($yaml["services"]["sched"]["ports"]);
    $yaml["services"]["sched"]["command"] = ["bash", "-c", "while true; do sleep 60; php /app/artisan schedule:run; done"];

    // Add a queue (clone the app service, remove ports!)	
    $yaml["services"]["queue"] = $yaml["services"]["app"];
    unset($yaml["services"]["queue"]["ports"]);
    $yaml["services"]["queue"]["command"] = ["bash", "-c", "sleep 15 && exec php /app/artisan queue:work --sleep=3 --tries=3"];

    // return the extended $yaml
    return $yaml;
};
```